### PR TITLE
天気予報アプリの画面レイアウトを構成する

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,8 +38,6 @@ class MyHomePage extends StatelessWidget {
                 flex: 1,
               ),
               Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
                 children: [
                   const AspectRatio(
                     aspectRatio: 1,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,9 @@ class MyHomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final double deviceWidth = MediaQuery.of(context).size.width;
 
+    final TextStyle? textThemeLabelLarge =
+        Theme.of(context).textTheme.labelLarge;
+
     return Scaffold(
       body: Container(
         margin: EdgeInsets.symmetric(horizontal: deviceWidth / 4),
@@ -49,17 +52,12 @@ class MyHomePage extends StatelessWidget {
                     children: [
                       Text(
                         '** ℃',
-                        style: Theme.of(context)
-                            .textTheme
-                            .labelLarge
-                            ?.copyWith(color: Colors.blue),
+                        style:
+                            textThemeLabelLarge?.copyWith(color: Colors.blue),
                       ),
                       Text(
                         '** ℃',
-                        style: Theme.of(context)
-                            .textTheme
-                            .labelLarge
-                            ?.copyWith(color: Colors.red),
+                        style: textThemeLabelLarge?.copyWith(color: Colors.red),
                       ),
                     ],
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,38 +29,67 @@ class MyHomePage extends StatelessWidget {
     return Scaffold(
       body: Container(
         margin: EdgeInsets.symmetric(vertical: 0, horizontal: deviceWidth / 4),
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const AspectRatio(
-                aspectRatio: 1,
-                child: Placeholder(),
-              ),
-              Container(
-                margin: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          children: [
+            const Expanded(
+              flex: 1,
+              child: SizedBox(),
+            ),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const AspectRatio(
+                  aspectRatio: 1,
+                  child: Placeholder(),
+                ),
+                Container(
+                  margin: const EdgeInsets.symmetric(vertical: 16),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      Text(
+                        '** ℃',
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelLarge
+                            ?.copyWith(color: Colors.blue),
+                      ),
+                      Text(
+                        '** ℃',
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelLarge
+                            ?.copyWith(color: Colors.red),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            Expanded(
+              flex: 1,
+              child: Container(
+                margin: const EdgeInsets.only(
+                  top: 80,
+                ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      '** ℃',
-                      style: Theme.of(context)
-                          .textTheme
-                          .labelLarge
-                          ?.copyWith(color: Colors.blue),
+                    TextButton(
+                      onPressed: () => {},
+                      child: const Text('Close'),
                     ),
-                    Text(
-                      '** ℃',
-                      style: Theme.of(context)
-                          .textTheme
-                          .labelLarge
-                          ?.copyWith(color: Colors.red),
+                    TextButton(
+                      onPressed: () => {},
+                      child: const Text('Reload'),
                     ),
                   ],
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,9 +31,8 @@ class MyHomePage extends StatelessWidget {
         margin: EdgeInsets.symmetric(horizontal: deviceWidth / 4),
         child: Column(
           children: [
-            const Expanded(
+            const Spacer(
               flex: 1,
-              child: SizedBox(),
             ),
             Column(
               mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,8 +66,7 @@ class MyHomePage extends StatelessWidget {
                 ),
               ],
             ),
-            Expanded(
-              flex: 1,
+            Flexible(
               child: Column(
                 children: [
                   const SizedBox(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,109 +7,35 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // Try running your application with "flutter run". You'll see the
-        // application has a blue toolbar. Then, without quitting the app, try
-        // changing the primarySwatch below to Colors.green and then invoke
-        // "hot reload" (press "r" in the console where you ran "flutter run",
-        // or simply save your changes to "hot reload" in a Flutter IDE).
-        // Notice that the counter didn't reset back to zero; the application
-        // is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
+    final double deviceWidth = MediaQuery.of(context).size.width;
+
     return Scaffold(
-      appBar: AppBar(
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ],
+      body: Container(
+        margin: EdgeInsets.symmetric(vertical: 0, horizontal: deviceWidth / 4),
+        child: const Center(
+          child: AspectRatio(
+            aspectRatio: 1,
+            child: Placeholder(),
+          ),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,84 +24,86 @@ class MyHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double deviceWidth = MediaQuery.of(context).size.width;
-
     final TextStyle? textThemeLabelLarge =
         Theme.of(context).textTheme.labelLarge;
 
     return Scaffold(
-      body: Container(
-        margin: EdgeInsets.symmetric(horizontal: deviceWidth / 4),
-        child: Column(
-          children: [
-            const Spacer(
-              flex: 1,
-            ),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const AspectRatio(
-                  aspectRatio: 1,
-                  child: Placeholder(),
-                ),
-                const SizedBox(
-                  height: 16,
-                ),
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        '** ℃',
-                        textAlign: TextAlign.center,
-                        style:
-                            textThemeLabelLarge?.copyWith(color: Colors.blue),
-                      ),
-                    ),
-                    Expanded(
-                      child: Text(
-                        '** ℃',
-                        textAlign: TextAlign.center,
-                        style: textThemeLabelLarge?.copyWith(color: Colors.red),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(
-                  height: 16,
-                ),
-              ],
-            ),
-            Flexible(
-              child: Column(
+      body: SizedBox.expand(
+        child: FractionallySizedBox(
+          widthFactor: 0.5,
+          alignment: FractionalOffset.center,
+          child: Column(
+            children: [
+              const Spacer(
+                flex: 1,
+              ),
+              Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
                 children: [
+                  const AspectRatio(
+                    aspectRatio: 1,
+                    child: Placeholder(),
+                  ),
                   const SizedBox(
-                    height: 80,
+                    height: 16,
                   ),
                   Row(
                     children: [
                       Expanded(
-                        child: Center(
-                          child: TextButton(
-                            onPressed: () => {},
-                            child: const Text('Close'),
-                          ),
+                        child: Text(
+                          '** ℃',
+                          textAlign: TextAlign.center,
+                          style:
+                              textThemeLabelLarge?.copyWith(color: Colors.blue),
                         ),
                       ),
                       Expanded(
-                        child: Center(
-                          child: TextButton(
-                            onPressed: () => {},
-                            child: const Text('Reload'),
-                          ),
+                        child: Text(
+                          '** ℃',
+                          textAlign: TextAlign.center,
+                          style:
+                              textThemeLabelLarge?.copyWith(color: Colors.red),
                         ),
                       ),
                     ],
                   ),
+                  const SizedBox(
+                    height: 16,
+                  ),
                 ],
               ),
-            ),
-          ],
+              Flexible(
+                child: Column(
+                  children: [
+                    const SizedBox(
+                      height: 80,
+                    ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Center(
+                            child: TextButton(
+                              onPressed: () => {},
+                              child: const Text('Close'),
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          child: Center(
+                            child: TextButton(
+                              onPressed: () => {},
+                              child: const Text('Reload'),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ class MyHomePage extends StatelessWidget {
 
     return Scaffold(
       body: Container(
-        margin: EdgeInsets.symmetric(vertical: 0, horizontal: deviceWidth / 4),
+        margin: EdgeInsets.symmetric(horizontal: deviceWidth / 4),
         child: Column(
           children: [
             const Expanded(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,15 +49,21 @@ class MyHomePage extends StatelessWidget {
                   height: 16,
                 ),
                 Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
-                    Text(
-                      '** ℃',
-                      style: textThemeLabelLarge?.copyWith(color: Colors.blue),
+                    Expanded(
+                      child: Text(
+                        '** ℃',
+                        textAlign: TextAlign.center,
+                        style:
+                            textThemeLabelLarge?.copyWith(color: Colors.blue),
+                      ),
                     ),
-                    Text(
-                      '** ℃',
-                      style: textThemeLabelLarge?.copyWith(color: Colors.red),
+                    Expanded(
+                      child: Text(
+                        '** ℃',
+                        textAlign: TextAlign.center,
+                        style: textThemeLabelLarge?.copyWith(color: Colors.red),
+                      ),
                     ),
                   ],
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,16 +79,22 @@ class MyHomePage extends StatelessWidget {
                     height: 80,
                   ),
                   Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      TextButton(
-                        onPressed: () => {},
-                        child: const Text('Close'),
+                      Expanded(
+                        child: Center(
+                          child: TextButton(
+                            onPressed: () => {},
+                            child: const Text('Close'),
+                          ),
+                        ),
                       ),
-                      TextButton(
-                        onPressed: () => {},
-                        child: const Text('Reload'),
+                      Expanded(
+                        child: Center(
+                          child: TextButton(
+                            onPressed: () => {},
+                            child: const Text('Reload'),
+                          ),
+                        ),
                       ),
                     ],
                   ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,45 +45,49 @@ class MyHomePage extends StatelessWidget {
                   aspectRatio: 1,
                   child: Placeholder(),
                 ),
-                Container(
-                  margin: const EdgeInsets.symmetric(vertical: 16),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceAround,
-                    children: [
-                      Text(
-                        '** ℃',
-                        style:
-                            textThemeLabelLarge?.copyWith(color: Colors.blue),
-                      ),
-                      Text(
-                        '** ℃',
-                        style: textThemeLabelLarge?.copyWith(color: Colors.red),
-                      ),
-                    ],
-                  ),
+                const SizedBox(
+                  height: 16,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    Text(
+                      '** ℃',
+                      style: textThemeLabelLarge?.copyWith(color: Colors.blue),
+                    ),
+                    Text(
+                      '** ℃',
+                      style: textThemeLabelLarge?.copyWith(color: Colors.red),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 16,
                 ),
               ],
             ),
             Expanded(
               flex: 1,
-              child: Container(
-                margin: const EdgeInsets.only(
-                  top: 80,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    TextButton(
-                      onPressed: () => {},
-                      child: const Text('Close'),
-                    ),
-                    TextButton(
-                      onPressed: () => {},
-                      child: const Text('Reload'),
-                    ),
-                  ],
-                ),
+              child: Column(
+                children: [
+                  const SizedBox(
+                    height: 80,
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      TextButton(
+                        onPressed: () => {},
+                        child: const Text('Close'),
+                      ),
+                      TextButton(
+                        onPressed: () => {},
+                        child: const Text('Reload'),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
           ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,10 +29,37 @@ class MyHomePage extends StatelessWidget {
     return Scaffold(
       body: Container(
         margin: EdgeInsets.symmetric(vertical: 0, horizontal: deviceWidth / 4),
-        child: const Center(
-          child: AspectRatio(
-            aspectRatio: 1,
-            child: Placeholder(),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const AspectRatio(
+                aspectRatio: 1,
+                child: Placeholder(),
+              ),
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    Text(
+                      '** ℃',
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelLarge
+                          ?.copyWith(color: Colors.blue),
+                    ),
+                    Text(
+                      '** ℃',
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelLarge
+                          ?.copyWith(color: Colors.red),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
## 概要

天気予報アプリの画面レイアウトを構成しました。

## スクリーンショット

<img alt="天気予報アプリの画面。中央にPlaceholderと気温が表示され、その下にCloseとReloadボタンが表示されている。" width="300" src="https://user-images.githubusercontent.com/30039352/200728951-fcde3311-a189-4cea-a08c-031f1a2705db.png" >
