### PR TITLE
Mixin パターンの実装

### DIFF
--- a/lib/foundation/mixin/after_render_mixin.dart
+++ b/lib/foundation/mixin/after_render_mixin.dart
@@ -4,8 +4,8 @@ import 'package:go_router/go_router.dart';
 
 mixin AfterRenderMixin on StatefulWidget {
   // 画面を描画後、0.5秒待機し画面遷移する
-  void moveAfterRender(
-      BuildContext context, String prevLocation, String nextLocation) {
+  void moveAfterRender(String prevLocation, String nextLocation) {
+    final context = useContext();
     final currentLocation = GoRouter.of(context).location;
 
     useEffect(() {

--- a/lib/foundation/mixin/after_render_mixin.dart
+++ b/lib/foundation/mixin/after_render_mixin.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-mixin AfterRenderMixin on StatefulWidget {
+mixin AfterRenderMixin on HookConsumerWidget {
   // 画面を描画後、0.5秒待機し画面遷移する
   void moveAfterRender(String prevLocation, String nextLocation) {
     final context = useContext();

--- a/lib/foundation/mixin/after_render_mixin.dart
+++ b/lib/foundation/mixin/after_render_mixin.dart
@@ -4,23 +4,29 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 mixin AfterRenderMixin on HookConsumerWidget {
-  // 画面を描画後、0.5秒待機し画面遷移する
-  void moveAfterRender(String prevLocation, String nextLocation) {
-    final context = useContext();
+  String get pageLocation;
+
+  void afterRender(BuildContext context);
+
+  Widget buildAfterSetup(BuildContext context, WidgetRef ref);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final currentLocation = GoRouter.of(context).location;
+    final isMounted = useIsMounted();
 
     useEffect(() {
-      if (currentLocation != prevLocation) return;
+      if (currentLocation != pageLocation) return null;
 
       WidgetsBinding.instance.endOfFrame.then(
         (_) {
-          Future.delayed(const Duration(milliseconds: 500), () {
-            context.push(nextLocation);
-          });
+          if (isMounted()) afterRender(context);
         },
       );
 
       return null;
     }, [currentLocation]);
+
+    return buildAfterSetup(context, ref);
   }
 }

--- a/lib/foundation/mixin/after_render_mixin.dart
+++ b/lib/foundation/mixin/after_render_mixin.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+
+mixin AfterRenderMixin on StatefulWidget {
+  // 画面を描画後、0.5秒待機し画面遷移する
+  void moveAfterRender(
+      BuildContext context, String prevLocation, String nextLocation) {
+    final currentLocation = GoRouter.of(context).location;
+
+    useEffect(() {
+      if (currentLocation != prevLocation) return;
+
+      WidgetsBinding.instance.endOfFrame.then(
+        (_) {
+          Future.delayed(const Duration(milliseconds: 500), () {
+            context.push(nextLocation);
+          });
+        },
+      );
+
+      return null;
+    }, [currentLocation]);
+  }
+}

--- a/lib/ui/pages/first_page.dart
+++ b/lib/ui/pages/first_page.dart
@@ -7,12 +7,18 @@ class FirstPage extends HookConsumerWidget with AfterRenderMixin {
   const FirstPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    moveAfterRender(
-      const FirstRoute().location,
-      const HomeRoute().location,
-    );
+  String get pageLocation => const FirstRoute().location;
 
+  @override
+  void afterRender(BuildContext context) {
+    // 画面を描画後、0.5秒待機し画面遷移する
+    Future.delayed(const Duration(milliseconds: 500), () {
+      const HomeRoute().push(context);
+    });
+  }
+
+  @override
+  Widget buildAfterSetup(BuildContext context, WidgetRef ref) {
     return const Scaffold();
   }
 }

--- a/lib/ui/pages/first_page.dart
+++ b/lib/ui/pages/first_page.dart
@@ -1,31 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_training/foundation/mixin/after_render_mixin.dart';
 import 'package:flutter_training/router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
-class FirstPage extends HookConsumerWidget {
+class FirstPage extends HookConsumerWidget with AfterRenderMixin {
   const FirstPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = GoRouter.of(context);
-    final firstRouteLocation = const FirstRoute().location;
-
-    // 画面を描画後、0.5秒待機し画面遷移する
-    useEffect(() {
-      if (router.location != firstRouteLocation) return;
-
-      WidgetsBinding.instance.endOfFrame.then(
-        (_) {
-          Future.delayed(const Duration(milliseconds: 500), () {
-            const HomeRoute().push(context);
-          });
-        },
-      );
-
-      return null;
-    }, [router.location]);
+    moveAfterRender(
+      context,
+      const FirstRoute().location,
+      const HomeRoute().location,
+    );
 
     return const Scaffold();
   }

--- a/lib/ui/pages/first_page.dart
+++ b/lib/ui/pages/first_page.dart
@@ -9,7 +9,6 @@ class FirstPage extends HookConsumerWidget with AfterRenderMixin {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     moveAfterRender(
-      context,
       const FirstRoute().location,
       const HomeRoute().location,
     );


### PR DESCRIPTION
## 概要

セッション3（lifecycle）で作成した「新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する」の部分をMixinを使用して実装しました。
on キーワードには HookConsumerWidget が継承している StatefulWidget を指定しました。

 ## 動画

https://user-images.githubusercontent.com/30039352/202212712-e4cb8868-3fe8-4742-8778-8c98fe4a6f38.mp4
